### PR TITLE
Fix: remove tower aim bug by adding group

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -28,4 +28,8 @@ window/stretch/mode="viewport"
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/gdscript_formatter/plugin.cfg")
+enabled=PackedStringArray()
+
+[global_group]
+
+enemy="All enemies"

--- a/scenes/enemy.tscn
+++ b/scenes/enemy.tscn
@@ -5,7 +5,7 @@
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_55jtl"]
 
-[node name="Enemy" type="CharacterBody2D"]
+[node name="Enemy" type="CharacterBody2D" groups=["enemy"]]
 script = ExtResource("1_md0e3")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]

--- a/scripts/tower.gd
+++ b/scripts/tower.gd
@@ -73,7 +73,7 @@ func shoot() -> void:
 
 
 func _on_aim_range_body_entered(body: Node2D) -> void:
-	if body == self:
+	if not body.is_in_group("enemy"):
 		return
 	enemies.append(body.get_parent())
 


### PR DESCRIPTION
I fixed the bug. Add a group "enemy" for the enemy to avoid aim the tower's parent (i.e. the map).