### PR TITLE
feat: attack finance

### DIFF
--- a/scripts/attack.gd
+++ b/scripts/attack.gd
@@ -1,26 +1,34 @@
 extends Control
 
-var enemy_list = [
+var enemy_list = {
+	"plane":
 	{
-		name = "plane",
 		icon_path =
-		"res://assets/kenney_tower-defense-top-down/PNG/Default size/towerDefense_tile270.png"
+		"res://assets/kenney_tower-defense-top-down/PNG/Default size/towerDefense_tile270.png",
+		cost = 100,
+		income = 1
 	},
+	"tank":
 	{
-		name = "tank",
-		icon_path = "res://assets/kenney_tower-defense-top-down/PNG/Retina/towerDefense_tile204.png"
-	},
-	{
-		name = "robot",
 		icon_path =
-		"res://.godot/imported/towerDefense_tile245.png-a634484bb16333c0b20a93f4d77d94ba.ctex"
+		"res://assets/kenney_tower-defense-top-down/PNG/Retina/towerDefense_tile204.png",
+		cost = 200,
+		income = 5
+	},
+	"robot":
+	{
+		icon_path =
+		"res://.godot/imported/towerDefense_tile245.png-a634484bb16333c0b20a93f4d77d94ba.ctex",
+		cost = 300,
+		income = 10
 	}
-]
+}
 
 @onready var enemy_grid = $AttackPanel/VBoxContainer/MarginContainer/EnemyList
 @onready var panel = $AttackPanel
 @onready var open_button = $OpenButton
 @onready var close_button = $AttackPanel/VBoxContainer/MarginContainer2/CloseButton
+@onready var game = get_node("/root/Game")
 
 
 func switch_panel_mode():
@@ -33,14 +41,14 @@ func _ready():
 	enemy_grid.custom_minimum_size = Vector2(300, 900)
 	for enemy in enemy_list:
 		var btn = TextureButton.new()
-		var tex = load(enemy.icon_path)
+		var tex = load(enemy_list[enemy].icon_path)
 		btn.texture_normal = tex
 		#btn.expand_icon = true
 		btn.stretch_mode = TextureButton.STRETCH_SCALE
 		btn.custom_minimum_size = Vector2(150, 100)
-		btn.name = enemy.name
+		btn.name = enemy
 
-		btn.pressed.connect(_on_avatar_pressed.bind(enemy.name))
+		btn.pressed.connect(_on_enemy_pressed.bind(enemy))
 		enemy_grid.add_child(btn)
 
 	self.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -49,8 +57,12 @@ func _ready():
 	close_button.pressed.connect(_on_close_button_pressed)
 
 
-func _on_avatar_pressed(avatar_name: String):
-	print("Avatar selected:", avatar_name)
+func _on_enemy_pressed(enemy: String):
+	if game.money < enemy_list[enemy].cost:
+		return
+	game.money -= enemy_list[enemy].cost
+	game.money_per_second += enemy_list[enemy].income
+	print("Avatar selected:", enemy)
 
 
 func _on_close_button_pressed():

--- a/scripts/attack.gd
+++ b/scripts/attack.gd
@@ -66,23 +66,24 @@ func _on_open_button_pressed():
 
 func _spawn_button(enemy: String):
 	var btn = Button.new()
-	#btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	#btn.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	btn.custom_minimum_size = Vector2(150, 175)
+	btn.custom_minimum_size = Vector2(150, 225)
 	btn.flat = true
 	btn.name = enemy
 
+	# For formatting
 	var vbox = VBoxContainer.new()
 	vbox.alignment = BoxContainer.ALIGNMENT_CENTER
 	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	vbox.size_flags_vertical = Control.SIZE_EXPAND_FILL
 
+	# Picture
 	var tex = TextureRect.new()
 	tex.texture = load(enemy_list[enemy].icon_path)
 	tex.stretch_mode = TextureRect.STRETCH_SCALE
 	tex.custom_minimum_size = Vector2(150, 150)
 	vbox.add_child(tex)
 
+	# Word Label
 	var cost_label = Label.new()
 	cost_label.text = "Cost: %d" % enemy_list[enemy].cost
 	cost_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER

--- a/scripts/attack.gd
+++ b/scripts/attack.gd
@@ -40,16 +40,7 @@ func switch_panel_mode():
 func _ready():
 	enemy_grid.custom_minimum_size = Vector2(300, 900)
 	for enemy in enemy_list:
-		var btn = TextureButton.new()
-		var tex = load(enemy_list[enemy].icon_path)
-		btn.texture_normal = tex
-		#btn.expand_icon = true
-		btn.stretch_mode = TextureButton.STRETCH_SCALE
-		btn.custom_minimum_size = Vector2(150, 100)
-		btn.name = enemy
-
-		btn.pressed.connect(_on_enemy_pressed.bind(enemy))
-		enemy_grid.add_child(btn)
+		_spawn_button(enemy)
 
 	self.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	panel.visible = false
@@ -71,3 +62,40 @@ func _on_close_button_pressed():
 
 func _on_open_button_pressed():
 	switch_panel_mode()
+
+
+func _spawn_button(enemy: String):
+	var btn = Button.new()
+	#btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	#btn.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	btn.custom_minimum_size = Vector2(150, 175)
+	btn.flat = true
+	btn.name = enemy
+
+	var vbox = VBoxContainer.new()
+	vbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.size_flags_vertical = Control.SIZE_EXPAND_FILL
+
+	var tex = TextureRect.new()
+	tex.texture = load(enemy_list[enemy].icon_path)
+	tex.stretch_mode = TextureRect.STRETCH_SCALE
+	tex.custom_minimum_size = Vector2(150, 150)
+	vbox.add_child(tex)
+
+	var cost_label = Label.new()
+	cost_label.text = "Cost: %d" % enemy_list[enemy].cost
+	cost_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	cost_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	vbox.add_child(cost_label)
+
+	var income_label = Label.new()
+	income_label.text = "Income: %d" % enemy_list[enemy].income
+	income_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	income_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	vbox.add_child(income_label)
+
+	btn.add_child(vbox)
+
+	btn.pressed.connect(_on_enemy_pressed.bind(enemy))
+	enemy_grid.add_child(btn)

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -8,7 +8,7 @@ var preview_tower
 var money: int = 0
 var money_per_second: int = 10
 var max_hp: int = 100
-var cost = 30
+var cost: int = 30
 var _money_timer := 0.0
 
 @onready var money_label: Label = $CanvasLayer/money_display
@@ -35,7 +35,7 @@ func _process(_delta):
 	var cell = tilemap.local_to_map(tilemap.to_local(mouse_pos))
 	var world_pos = tilemap.map_to_local(cell)
 	preview_tower.global_position = tilemap.to_global(world_pos)
-	preview_tower.visible = handle_visibility_of_preview_tower()
+	preview_tower.visible = _handle_visibility_of_preview_tower()
 
 	var valid = can_place_tower(cell)
 	set_tower_color(preview_tower, valid)
@@ -96,7 +96,7 @@ func set_hit_point(damage: int):
 	hp_bar.value -= damage
 
 
-func handle_visibility_of_preview_tower():
+func _handle_visibility_of_preview_tower():
 	if (
 		attack_ui.panel.visible
 		and attack_ui.panel.get_global_rect().has_point(get_global_mouse_position())

--- a/scripts/spawner.gd
+++ b/scripts/spawner.gd
@@ -37,11 +37,11 @@ func spawn_enemy(ratio: float, path: Path2D, type: EnemySource):
 			opponent_enemy_spawned += 1
 
 
-func spawn_system_enemy():
+func _spawn_system_enemy():
 	spawn_enemy(0.0, system_path, EnemySource.SYSTEM)
 
 
-func spawn_opponent_enemy():
+func _spawn_opponent_enemy():
 	spawn_enemy(0.0, opponent_path, EnemySource.OPPONENT)
 
 
@@ -50,6 +50,6 @@ func _on_spawn_timeout():
 		spawn_timer.stop()
 		return
 	if system_enemy_spawned < max_system_enemy:
-		spawn_system_enemy()
+		_spawn_system_enemy()
 	if opponent_enemy_spawned < max_opponent_enemy:
-		spawn_opponent_enemy()
+		_spawn_opponent_enemy()


### PR DESCRIPTION
- Each type of attack should attach with a cost and an effect on income.
- Most attacks should increase the number of money got per 5s.
- Display the money required for attack and the effect on income on the attack panel.