### PR TITLE
Fix/spell trigger

### DIFF
--- a/data/units.json
+++ b/data/units.json
@@ -3,10 +3,10 @@
 	"scene_path": "res://scenes/enemies/goomba.tscn",
 	"stats": {
 		"deploy_cost": 10,
+		"income_impact": 0,
 		"max_health": 10,
 		"max_speed": 50,
 		"damage": 5,
-		"income_impact": 0,
 		"flying": false,
 		"armor": 0,
 		"shield": 0,
@@ -18,11 +18,11 @@
 	"scene_path": "res://scenes/enemies/koopa_paratroopa.tscn",
 	"stats": {
 		"deploy_cost": 20,
+		"income_impact": 2,
 		"max_health": 15,
 		"max_speed": 80,
 		"damage": 7,
-		"income_impact": 2,
-		"flying": false,
+		"flying": true,
 		"armor": 0,
 		"shield": 0,
 		"knockback_resist": false,
@@ -55,7 +55,7 @@
 		"flying": false,
 		"armor": 0,
 		"shield": 0,
-		"knockback_resist": false,
+		"knockback_resist": true,
 		"kill_reward": 1
 	}
   },
@@ -82,7 +82,7 @@
 		"max_health": 40,
 		"max_speed": 70,
 		"damage": 25,
-		"flying": false,
+		"flying": true,
 		"armor": 0,
 		"shield": 0,
 		"knockback_resist": false,
@@ -100,7 +100,7 @@
 		"flying": false,
 		"armor": 0,
 		"shield": 0,
-		"knockback_resist": false,
+		"knockback_resist": true,
 		"kill_reward": 1
 	}
   }

--- a/data/units.json
+++ b/data/units.json
@@ -3,20 +3,30 @@
 	"scene_path": "res://scenes/enemies/goomba.tscn",
 	"stats": {
 		"deploy_cost": 10,
-		"income_impact": 1,
 		"max_health": 10,
 		"max_speed": 50,
-		"damage": 5
+		"damage": 5,
+		"income_impact": 0,
+		"flying": false,
+		"armor": 0,
+		"shield": 0,
+		"knockback_resist": false,
+		"kill_reward": 1
 	}
   },
   "koopa_paratroopa": {
 	"scene_path": "res://scenes/enemies/koopa_paratroopa.tscn",
 	"stats": {
 		"deploy_cost": 20,
-		"income_impact": 2,
 		"max_health": 15,
 		"max_speed": 80,
-		"damage": 7
+		"damage": 7,
+		"income_impact": 2,
+		"flying": false,
+		"armor": 0,
+		"shield": 0,
+		"knockback_resist": false,
+		"kill_reward": 1
 	}
   },
   "spiny_shell": {
@@ -26,7 +36,12 @@
 		"income_impact": 3,
 		"max_health": 20,
 		"max_speed": 120,
-		"damage": 10
+		"damage": 10,
+		"flying": false,
+		"armor": 0,
+		"shield": 0,
+		"knockback_resist": false,
+		"kill_reward": 1
 	}
   },
   "buzzy_beetle": {
@@ -36,7 +51,12 @@
 		"income_impact": 4,
 		"max_health": 25,
 		"max_speed": 75,
-		"damage": 8
+		"damage": 8,
+		"flying": false,
+		"armor": 0,
+		"shield": 0,
+		"knockback_resist": false,
+		"kill_reward": 1
 	}
   },
   "wiggler": {
@@ -46,7 +66,12 @@
 		"income_impact": 5,
 		"max_health": 60,
 		"max_speed": 60,
-		"damage": 12
+		"damage": 12,
+		"flying": false,
+		"armor": 0,
+		"shield": 0,
+		"knockback_resist": false,
+		"kill_reward": 1
 	}
   },
   "koopa_jr": {
@@ -56,7 +81,12 @@
 		"income_impact": -1,
 		"max_health": 40,
 		"max_speed": 70,
-		"damage": 25
+		"damage": 25,
+		"flying": false,
+		"armor": 0,
+		"shield": 0,
+		"knockback_resist": false,
+		"kill_reward": 1
 	}
   },
   "koopa": {
@@ -66,7 +96,12 @@
 		"income_impact": -5,
 		"max_health": 100,
 		"max_speed": 20,
-		"damage": 60
+		"damage": 60,
+		"flying": false,
+		"armor": 0,
+		"shield": 0,
+		"knockback_resist": false,
+		"kill_reward": 1
 	}
   }
 }

--- a/scenes/enemies/koopa_paratroopa.tscn
+++ b/scenes/enemies/koopa_paratroopa.tscn
@@ -19,7 +19,7 @@ animations = [{
 }]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_55jtl"]
-radius = 17.0294
+radius = 20.0998
 
 [node name="Enemy" type="Area2D" groups=["EnemyGroup"]]
 collision_layer = 4
@@ -29,10 +29,10 @@ flying = true
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 sprite_frames = SubResource("SpriteFrames_772r1")
-frame_progress = 0.714216
+frame_progress = 0.0675438
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(-1, -10)
+position = Vector2(0, -9)
 shape = SubResource("CircleShape2D_55jtl")
 
 [node name="HealthBar" type="ProgressBar" parent="."]

--- a/scenes/player_status.tscn
+++ b/scenes/player_status.tscn
@@ -91,7 +91,7 @@ offset_bottom = 25.5
 grow_vertical = 2
 theme_override_colors/font_color = Color(0.6624, 0.92, 0.6624, 1)
 theme_override_font_sizes/font_size = 36
-text = "+123"
+text = "+10"
 vertical_alignment = 1
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]

--- a/scenes/spells/poison_effect.tscn
+++ b/scenes/spells/poison_effect.tscn
@@ -19,10 +19,8 @@ texture = ExtResource("2_2p3g5")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_mxvwf")
 
-[node name="TriggerTimer" type="Timer" parent="."]
-one_shot = true
-autostart = true
-
 [node name="DurationTimer" type="Timer" parent="."]
 one_shot = true
 autostart = true
+
+[connection signal="area_entered" from="." to="." method="_on_area_entered"]

--- a/scripts/enemy/enemy.gd
+++ b/scripts/enemy/enemy.gd
@@ -1,21 +1,21 @@
 class_name Enemy
 extends Area2D
 
+@export var income_impact: int = 0
 @export var max_health: int = 100
 # Note that the speed of enemy should never exceed that of explosion of effect,
 # error may occur otherwise
 @export var max_speed: int = 50
-@export var flying: bool = false
 @export var damage: int = 5
+@export var flying: bool = false
 @export var armor: int = 0
 @export var shield: int = 0
 @export var knockback_resist: bool = false
 @export var kill_reward: int = 1
-@export var income_impact: int = 0
 
 var game: Game
 var path_follow: PathFollow2D
-var knockback_ratio: float = 0.1
+var knockback_distance: int = 200
 var source: Game.EnemySource
 var health: int:
 	get:
@@ -76,12 +76,12 @@ func _on_area_entered(bullet: Bullet) -> void:
 func knockback(far: bool):
 	if far:
 		if knockback_resist:
-			path_follow.progress_ratio -= knockback_ratio
+			path_follow.progress -= knockback_distance
 		else:
-			path_follow.progress_ratio -= knockback_ratio * 2
+			path_follow.progress -= knockback_distance * 2
 	else:
 		if not knockback_resist:
-			path_follow.progress_ratio -= knockback_ratio
+			path_follow.progress -= knockback_distance
 
 
 func freeze(rate: float):

--- a/scripts/enemy/enemy.gd
+++ b/scripts/enemy/enemy.gd
@@ -15,7 +15,7 @@ extends Area2D
 
 var game: Game
 var path_follow: PathFollow2D
-var knockback_distance: int = 200
+var knockback_distance: int = 50
 var source: Game.EnemySource
 var health: int:
 	get:

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -172,6 +172,17 @@ func _initialize_enemy_from_data(unit_data: Dictionary) -> Enemy:
 	enemy.max_health = stats.max_health
 	enemy.max_speed = stats.max_speed
 	enemy.damage = stats.damage
+	enemy.flying = stats.flying
+	enemy.armor = stats.armor
+	enemy.shield = stats.shield
+	enemy.knockback_resist = stats.knockback_resist
+	enemy.kill_reward = stats.kill_reward
+	if enemy.flying:
+		enemy.collision_layer = 4
+		enemy.collision_mask = 8
+	else:
+		enemy.collision_layer = 1
+		enemy.collision_mask = 2
 	return enemy
 
 

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -22,7 +22,7 @@ var money: int = 100
 var income_per_second = 10
 var kill_cnt = 0
 var player_selection: IndividualPlayerSelection = null
-var income_rate: float = 1
+var income_rate: int = 1
 var built_towers: Dictionary = {}
 var previewer: Previewer = null
 var spell_dict: Dictionary
@@ -236,7 +236,7 @@ func _place_spell(cell_pos: Vector2i, spell_node) -> void:
 
 func _process(_delta) -> void:
 	status_panel.find_child("Money").text = "%d" % money
-	status_panel.find_child("Income").text = "+%d" % income_per_second
+	status_panel.find_child("Income").text = "+%d" % [income_per_second * income_rate]
 
 
 func _unhandled_input(event: InputEvent) -> void:

--- a/scripts/spells/poison_effect.gd
+++ b/scripts/spells/poison_effect.gd
@@ -3,7 +3,6 @@ extends Area2D
 @onready var spell: PoisonSpell = get_parent()
 @onready var collision: CollisionShape2D = $CollisionShape2D
 @onready var duration_timer: Timer = $DurationTimer
-@onready var trigger_timer: Timer = $TriggerTimer
 
 
 func _ready():
@@ -11,25 +10,16 @@ func _ready():
 	# Create duration timer
 	duration_timer.timeout.connect(_on_duration_ended)
 	duration_timer.wait_time = spell.metadata.stats.duration
-	# Create trigger timer
-	trigger_timer.timeout.connect(_on_trigger)
-	trigger_timer.wait_time = spell.metadata.stats.trigger_interval
 
 
 func _draw():
 	draw_circle(Vector2.ZERO, spell.metadata.stats.radius, Color.BLUE)
 
 
-func trigger() -> void:
-	# TODO: trigger damage anytime instead of only at the end
-	var enemies: Array[Area2D] = get_overlapping_areas()
-	for enemy in enemies:
-		enemy.take_damage(spell.metadata.stats.trigger_damage)
-
-
-func _on_trigger():
-	trigger()
-
-
 func _on_duration_ended():
 	queue_free()
+
+
+func _on_area_entered(area: Area2D) -> void:
+	if area.is_in_group("enemies"):
+		area.take_damage(spell.metadata.stats.trigger_damage)

--- a/scripts/spells/poison_effect.gd
+++ b/scripts/spells/poison_effect.gd
@@ -21,6 +21,7 @@ func _draw():
 
 
 func trigger() -> void:
+	# TODO: trigger damage anytime instead of only at the end
 	var enemies: Array[Area2D] = get_overlapping_areas()
 	for enemy in enemies:
 		enemy.take_damage(spell.metadata.stats.trigger_damage)


### PR DESCRIPTION
修復各種 bug
- `Status/Income` 這個 label 改成顯示 `income_per_second * income_rate`
- 擊退改成 `progress -= knockback_distance`，其中 `knockback_distance = 50`
  - 將擊退距離調小使擊退不會看起來像消失
- 在 `units.json` 中添加所有敵人的 attributes，並在 `game.gd` 中依 `flying` 屬性設定 `collision`
- `poison` 從「消失時 trigger」改成「任意時刻進入範圍都會 `take_damage`」