### PR TITLE
feat/preview ranges

### DIFF
--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -154,6 +154,7 @@ func _select_tower(tower: Tower, left: bool, up: bool):
 	var tower_ui: TowerUi = TOWER_UI_SCENE.instantiate()
 	tower.add_child(tower_ui)
 	tower_ui.global_position = tower.global_position
+	tower_ui.initialize(tower)
 	await get_tree().process_frame
 	var ui_size = tower_ui.size
 	if left:

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -145,6 +145,7 @@ func _on_buy_tower(tower_scene: PackedScene):
 		self.remove_child(previewer)
 		previewer.free()
 	previewer = Previewer.new(tower, preview_color_callback, map, true)
+	previewer.show_attack_range(tower.aim_range)
 	previewer.selected.connect(self.place_tower.bind(tower))
 	self.add_child(previewer)
 

--- a/scripts/previewer.gd
+++ b/scripts/previewer.gd
@@ -9,6 +9,7 @@ enum PreviewMode {
 	FAIL,
 }
 
+var range_circle = null
 var _previewed_node: Node
 
 # this is called every frame for updating the color of previewed object
@@ -85,3 +86,24 @@ func _process(_delta: float) -> void:
 			modulate = Color(0, 1, 0, 0.5)
 		PreviewMode.FAIL:
 			modulate = Color(1, 0, 0, 0.5)
+
+
+func _create_range_circle(radius: float) -> Line2D:
+	var circle := Line2D.new()
+	circle.width = 5
+	circle.default_color = Color(1, 1, 1, 0.3)
+	circle.closed = true
+
+	var segments := 64
+	for i in segments:
+		var angle = TAU * i / segments
+		var point = Vector2(cos(angle), sin(angle)) * radius
+		circle.add_point(point)
+	return circle
+
+
+func show_attack_range(radius: float) -> void:
+	if range_circle:
+		range_circle.queue_free()
+	range_circle = _create_range_circle(radius)
+	add_child(range_circle)

--- a/scripts/towers/tower_ui.gd
+++ b/scripts/towers/tower_ui.gd
@@ -3,6 +3,14 @@ extends Control
 
 signal sold
 
+var tower: Tower
+var range_circle = null
+
+
+func initialize(t: Tower):
+	tower = t
+	_draw_attack_range(tower.aim_range)
+
 
 # the tower's UI intercepts input events before GUI (because it is impossible to trigger both)
 func _input(event):
@@ -33,3 +41,24 @@ func _on_close_button_pressed() -> void:
 func _on_last_button_pressed() -> void:
 	get_parent().strategy = Tower.TargetStrategy.LAST
 	queue_free()
+
+
+func _create_range_circle(radius: float) -> Line2D:
+	var circle := Line2D.new()
+	circle.width = 5
+	circle.default_color = Color(1, 1, 1, 0.3)
+	circle.closed = true
+
+	var segments := 64
+	for i in segments:
+		var angle = TAU * i / segments
+		var point = Vector2(cos(angle), sin(angle)) * radius
+		circle.add_point(point)
+	return circle
+
+
+func _draw_attack_range(radius: float) -> void:
+	if range_circle:
+		range_circle.queue_free()
+	range_circle = _create_range_circle(radius)
+	add_child(range_circle)


### PR DESCRIPTION
- 商店中點塔，鼠標移到地圖上預覽時可以預覽攻擊距離
- 點擊已蓋好的塔，會跟著TowerUI顯示其攻擊距離，也會跟著TowerUI一起關閉