### PR TITLE
feat: disable scroll_to_end when mouse hover

### DIFF
--- a/scripts/chat.gd
+++ b/scripts/chat.gd
@@ -67,8 +67,10 @@ func send_chat_with_sender(
 	textbox.set_meta("sender", sender_id)
 	textbox.set_line_height(send_pixelcat)
 	$MarginContainer/ScrollContainer/VBoxContainer.add_child(textbox)
-	await get_tree().process_frame
-	scrollbar.scroll_vertical = scrollbar.get_v_scroll_bar().max_value
+
+	if not get_global_rect().has_point(get_global_mouse_position()):
+		await get_tree().process_frame
+		scrollbar.scroll_vertical = scrollbar.get_v_scroll_bar().max_value
 
 
 func _on_switch_pressed() -> void:


### PR DESCRIPTION
如題，在鼠標停在 Chat 上時不會 scroll to end，方便瀏覽歷史訊息。