### PR TITLE
fix: run super's ready function to initialize wiggler properly

### DIFF
--- a/scripts/enemy/wiggler.gd
+++ b/scripts/enemy/wiggler.gd
@@ -2,6 +2,7 @@ extends Enemy
 
 
 func _ready() -> void:
+	super._ready()
 	var use_zhaobu = randf() < 0.1
 	if use_zhaobu:
 		$AnimatedSprite2D.play("new_animation")


### PR DESCRIPTION
如題。正確初始化血量速度等數值。